### PR TITLE
Fix: track ride page is now mobile responsive

### DIFF
--- a/client-layer/src/app/components/map/map.css
+++ b/client-layer/src/app/components/map/map.css
@@ -9,3 +9,18 @@
     width: 100%;   
     height: 100%;  
 }
+
+@media (max-width: 767px) {
+    .map-frame {
+        width: 100%;
+        height: 40vh;
+        min-height: 300px;
+        flex: none;
+        box-sizing: border-box; 
+    }
+
+    #map {
+        width: 100%;
+        height: 100%;
+    }
+}

--- a/client-layer/src/app/components/track-ride/ride-info/ride-info.css
+++ b/client-layer/src/app/components/track-ride/ride-info/ride-info.css
@@ -20,7 +20,7 @@
 
 .ride-info p {
   margin: 6px 0;
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.4;
 }
 
@@ -44,9 +44,5 @@
 @media (max-width: 767px) {
   .ride-info {
     padding: 12px;
-  }
-
-  .ride-info p {
-    font-size: 13px;
   }
 }

--- a/client-layer/src/app/pages/registered-home/registered-home.css
+++ b/client-layer/src/app/pages/registered-home/registered-home.css
@@ -25,3 +25,14 @@
   color: #666;
   line-height: 1.6;
 }
+
+@media (max-width: 767px) {
+  .content-wrapper {
+    flex-direction: column; 
+  }
+
+  .right-panel {
+    padding: 12px;
+    height: auto;
+  }
+}

--- a/client-layer/src/app/pages/track-ride-page/track-ride-page.css
+++ b/client-layer/src/app/pages/track-ride-page/track-ride-page.css
@@ -6,7 +6,6 @@
 .content-wrapper {
   display: flex;
   height: 100%;
-  overflow: hidden;
 }
 
 .right-panel {
@@ -14,4 +13,15 @@
   padding: 20px;
   background-color: #ffffff;
   overflow-y: auto;
+}
+
+@media (max-width: 767px) {
+  .content-wrapper {
+    flex-direction: column; 
+  }
+
+  .right-panel {
+    padding: 12px;
+    height: auto;
+  }
 }

--- a/client-layer/src/app/pages/unregistered-home/unregistered-home.css
+++ b/client-layer/src/app/pages/unregistered-home/unregistered-home.css
@@ -25,3 +25,14 @@
   color: #666;
   line-height: 1.6;
 }
+
+@media (max-width: 767px) {
+  .content-wrapper {
+    flex-direction: column; 
+  }
+
+  .right-panel {
+    padding: 12px;
+    height: auto;
+  }
+}


### PR DESCRIPTION
- map is at the top of the screen and all the data is below

- also fixed unregistered and registered user home page to use map on top and data below

- part of #66 