### PR TITLE
Panic, stop and cancel buttons added on track ride page

### DIFF
--- a/mobile-application/app/src/main/java/com/example/mobile_application/dto/CancelRideRequestDTO.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/dto/CancelRideRequestDTO.java
@@ -1,0 +1,22 @@
+package com.example.mobile_application.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+public class CancelRideRequestDTO {
+    @SerializedName("userId")
+    private Long userId;
+    @SerializedName("reason")
+    private String reason;
+
+    public CancelRideRequestDTO() {}
+
+    public CancelRideRequestDTO(Long userId, String reason) {
+        this.userId = userId;
+        this.reason = reason;
+    }
+
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/dto/CancelRideResponseDTO.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/dto/CancelRideResponseDTO.java
@@ -1,0 +1,26 @@
+
+package com.example.mobile_application.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+public class CancelRideResponseDTO {
+    @SerializedName("rideId")
+    private Long rideId;
+    @SerializedName("cancelledBy")
+    private Long cancelledBy;
+    @SerializedName("reason")
+    private String reason;
+    @SerializedName("message")
+    private String message;
+
+    public CancelRideResponseDTO() {}
+
+    public Long getRideId() { return rideId; }
+    public void setRideId(Long rideId) { this.rideId = rideId; }
+    public Long getCancelledBy() { return cancelledBy; }
+    public void setCancelledBy(Long cancelledBy) { this.cancelledBy = cancelledBy; }
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/dto/PanicAlertRequestDTO.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/dto/PanicAlertRequestDTO.java
@@ -1,0 +1,28 @@
+
+package com.example.mobile_application.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+public class PanicAlertRequestDTO {
+    @SerializedName("rideId")
+    private Long rideId;
+    @SerializedName("userId")
+    private Long userId;
+    @SerializedName("currentLocation")
+    private String currentLocation;
+
+    public PanicAlertRequestDTO() {}
+
+    public PanicAlertRequestDTO(Long rideId, Long userId, String currentLocation) {
+        this.rideId = rideId;
+        this.userId = userId;
+        this.currentLocation = currentLocation;
+    }
+
+    public Long getRideId() { return rideId; }
+    public void setRideId(Long rideId) { this.rideId = rideId; }
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+    public String getCurrentLocation() { return currentLocation; }
+    public void setCurrentLocation(String currentLocation) { this.currentLocation = currentLocation; }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/dto/PanicAlertResponseDTO.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/dto/PanicAlertResponseDTO.java
@@ -1,0 +1,38 @@
+
+package com.example.mobile_application.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+public class PanicAlertResponseDTO {
+    @SerializedName("id")
+    private Long id;
+    @SerializedName("rideId")
+    private Long rideId;
+    @SerializedName("triggeredByUserId")
+    private Long triggeredByUserId;
+    @SerializedName("triggeredByName")
+    private String triggeredByName;
+    @SerializedName("currentLocation")
+    private String currentLocation;
+    @SerializedName("triggeredAt")
+    private String triggeredAt;
+    @SerializedName("resolved")
+    private boolean resolved;
+
+    public PanicAlertResponseDTO() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Long getRideId() { return rideId; }
+    public void setRideId(Long rideId) { this.rideId = rideId; }
+    public Long getTriggeredByUserId() { return triggeredByUserId; }
+    public void setTriggeredByUserId(Long triggeredByUserId) { this.triggeredByUserId = triggeredByUserId; }
+    public String getTriggeredByName() { return triggeredByName; }
+    public void setTriggeredByName(String triggeredByName) { this.triggeredByName = triggeredByName; }
+    public String getCurrentLocation() { return currentLocation; }
+    public void setCurrentLocation(String currentLocation) { this.currentLocation = currentLocation; }
+    public String getTriggeredAt() { return triggeredAt; }
+    public void setTriggeredAt(String triggeredAt) { this.triggeredAt = triggeredAt; }
+    public boolean isResolved() { return resolved; }
+    public void setResolved(boolean resolved) { this.resolved = resolved; }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/dto/StopRideRequestDTO.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/dto/StopRideRequestDTO.java
@@ -1,0 +1,23 @@
+
+package com.example.mobile_application.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+public class StopRideRequestDTO {
+    @SerializedName("currentLocation")
+    private String currentLocation;
+    @SerializedName("stoppedAt")
+    private String stoppedAt;
+
+    public StopRideRequestDTO() {}
+
+    public StopRideRequestDTO(String currentLocation, String stoppedAt) {
+        this.currentLocation = currentLocation;
+        this.stoppedAt = stoppedAt;
+    }
+
+    public String getCurrentLocation() { return currentLocation; }
+    public void setCurrentLocation(String currentLocation) { this.currentLocation = currentLocation; }
+    public String getStoppedAt() { return stoppedAt; }
+    public void setStoppedAt(String stoppedAt) { this.stoppedAt = stoppedAt; }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/dto/StopRideResponseDTO.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/dto/StopRideResponseDTO.java
@@ -1,0 +1,30 @@
+
+package com.example.mobile_application.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+public class StopRideResponseDTO {
+    @SerializedName("rideId")
+    private Long rideId;
+    @SerializedName("stoppedLocation")
+    private String stoppedLocation;
+    @SerializedName("stoppedAt")
+    private String stoppedAt;
+    @SerializedName("recalculatedPrice")
+    private double recalculatedPrice;
+    @SerializedName("message")
+    private String message;
+
+    public StopRideResponseDTO() {}
+
+    public Long getRideId() { return rideId; }
+    public void setRideId(Long rideId) { this.rideId = rideId; }
+    public String getStoppedLocation() { return stoppedLocation; }
+    public void setStoppedLocation(String stoppedLocation) { this.stoppedLocation = stoppedLocation; }
+    public String getStoppedAt() { return stoppedAt; }
+    public void setStoppedAt(String stoppedAt) { this.stoppedAt = stoppedAt; }
+    public double getRecalculatedPrice() { return recalculatedPrice; }
+    public void setRecalculatedPrice(double recalculatedPrice) { this.recalculatedPrice = recalculatedPrice; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/repository/PanicRepository.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/repository/PanicRepository.java
@@ -1,0 +1,29 @@
+
+package com.example.mobile_application.repository;
+
+import com.example.mobile_application.dto.PanicAlertRequestDTO;
+import com.example.mobile_application.dto.PanicAlertResponseDTO;
+import com.example.mobile_application.service.ApiClient;
+import com.example.mobile_application.service.PanicService;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+
+public class PanicRepository {
+    private final PanicService service;
+
+    public PanicRepository() {
+        service = ApiClient.getInstance().create(PanicService.class);
+    }
+
+    public void triggerPanic(PanicAlertRequestDTO request,
+                             Callback<PanicAlertResponseDTO> callback) {
+        Call<PanicAlertResponseDTO> call = service.triggerPanic(request);
+
+        android.util.Log.d("PANIC_DEBUG", "URL: " + call.request().url());
+        android.util.Log.d("PANIC_DEBUG", "RideId: " + request.getRideId()
+                + " UserId: " + request.getUserId());
+
+        call.enqueue(callback);
+    }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/repository/RideCancelRepository.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/repository/RideCancelRepository.java
@@ -1,0 +1,24 @@
+
+package com.example.mobile_application.repository;
+
+import com.example.mobile_application.dto.CancelRideRequestDTO;
+import com.example.mobile_application.dto.CancelRideResponseDTO;
+import com.example.mobile_application.service.ApiClient;
+import com.example.mobile_application.service.RideCancelService;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+
+public class RideCancelRepository {
+    private final RideCancelService service;
+
+    public RideCancelRepository() {
+        service = ApiClient.getInstance().create(RideCancelService.class);
+    }
+
+    public void cancelRide(Long rideId, CancelRideRequestDTO request,
+                           Callback<CancelRideResponseDTO> callback) {
+        Call<CancelRideResponseDTO> call = service.cancelRide(rideId, request);
+        call.enqueue(callback);
+    }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/repository/RideStopRepository.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/repository/RideStopRepository.java
@@ -1,0 +1,24 @@
+
+package com.example.mobile_application.repository;
+
+import com.example.mobile_application.dto.StopRideRequestDTO;
+import com.example.mobile_application.dto.StopRideResponseDTO;
+import com.example.mobile_application.service.ApiClient;
+import com.example.mobile_application.service.RideStopService;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+
+public class RideStopRepository {
+    private final RideStopService service;
+
+    public RideStopRepository() {
+        service = ApiClient.getInstance().create(RideStopService.class);
+    }
+
+    public void stopRide(Long rideId, StopRideRequestDTO request,
+                         Callback<StopRideResponseDTO> callback) {
+        Call<StopRideResponseDTO> call = service.stopRide(rideId, request);
+        call.enqueue(callback);
+    }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/service/PanicService.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/service/PanicService.java
@@ -1,0 +1,14 @@
+
+package com.example.mobile_application.service;
+
+import com.example.mobile_application.dto.PanicAlertRequestDTO;
+import com.example.mobile_application.dto.PanicAlertResponseDTO;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
+
+public interface PanicService {
+    @POST("api/panic")
+    Call<PanicAlertResponseDTO> triggerPanic(@Body PanicAlertRequestDTO request);
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/service/RideCancelService.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/service/RideCancelService.java
@@ -1,0 +1,17 @@
+
+package com.example.mobile_application.service;
+
+import com.example.mobile_application.dto.CancelRideRequestDTO;
+import com.example.mobile_application.dto.CancelRideResponseDTO;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+public interface RideCancelService {
+    @POST("api/rides/{rideId}/cancel")
+    Call<CancelRideResponseDTO> cancelRide(
+            @Path("rideId") Long rideId,
+            @Body CancelRideRequestDTO request);
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/service/RideStopService.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/service/RideStopService.java
@@ -1,0 +1,17 @@
+
+package com.example.mobile_application.service;
+
+import com.example.mobile_application.dto.StopRideRequestDTO;
+import com.example.mobile_application.dto.StopRideResponseDTO;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+public interface RideStopService {
+    @POST("api/rides/{rideId}/stop")
+    Call<StopRideResponseDTO> stopRide(
+            @Path("rideId") Long rideId,
+            @Body StopRideRequestDTO request);
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/ui/FavoriteRoutesFragment.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/ui/FavoriteRoutesFragment.java
@@ -55,14 +55,21 @@ public class FavoriteRoutesFragment extends BaseRideBookingFragment {
         return inflater.inflate(R.layout.fragment_favorite_routes, container, false);
     }
 
+
     @Override
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         initializeFavoritesViews(view);
         initializeScheduleRideViews(view);
-        setupMap();
-        setupAutocomplete();
+
+        // Only setup map if the layout actually has a map view
+        if (mapView != null) {
+            initializeMarkerIcon();
+            setupMap();
+            setupAutocomplete();
+        }
+
         setupBottomSheet(view);
         setupSpinners();
         setupNumberPickers();
@@ -77,7 +84,6 @@ public class FavoriteRoutesFragment extends BaseRideBookingFragment {
             errorMessage.setVisibility(View.VISIBLE);
             recyclerView.setVisibility(View.GONE);
             emptyState.setVisibility(View.GONE);
-            // Hide the schedule ride card
             View scheduleRideCard = view.findViewById(R.id.schedule_ride_card);
             if (scheduleRideCard != null) {
                 scheduleRideCard.setVisibility(View.GONE);
@@ -93,7 +99,6 @@ public class FavoriteRoutesFragment extends BaseRideBookingFragment {
 
         loadFavoriteRoutes();
     }
-
     private void initializeFavoritesViews(View view) {
         recyclerView = view.findViewById(R.id.recycler_view_routes);
         progressBar = view.findViewById(R.id.progress_bar);

--- a/mobile-application/app/src/main/java/com/example/mobile_application/ui/base/BaseRideBookingFragment.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/ui/base/BaseRideBookingFragment.java
@@ -38,6 +38,7 @@ import com.example.mobile_application.enums.VehicleType;
 import com.example.mobile_application.service.ApiClient;
 import com.example.mobile_application.service.TokenManager;
 import com.example.mobile_application.ui.AddressAutocompleteAdapter;
+import com.example.mobile_application.ui.track_ride.TrackRideFragment;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.card.MaterialCardView;
 import com.google.android.material.switchmaterial.SwitchMaterial;
@@ -571,6 +572,7 @@ public abstract class BaseRideBookingFragment extends Fragment {
         }
     }
 
+    
     private void handleRideBookingSuccess(Call<RideResponseDTO> call, Response<RideResponseDTO> response) {
         RideResponseDTO rideResponse = response.body();
         String message = "Ride booked successfully!\n" +
@@ -581,6 +583,20 @@ public abstract class BaseRideBookingFragment extends Fragment {
         if (bottomSheetBehavior != null) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
         }
+
+        // Navigate to TrackRideFragment with the new ride ID
+        navigateToTrackRide(rideResponse.getRideId());
+    }
+
+    private void navigateToTrackRide(Long rideId) {
+        if (!isAdded() || rideId == null) return;
+
+        Fragment trackRideFragment = TrackRideFragment.newInstance(rideId);
+        requireActivity().getSupportFragmentManager()
+                .beginTransaction()
+                .replace(R.id.main_container, trackRideFragment)
+                .addToBackStack(null)
+                .commit();
     }
 
     private void handleRideBookingError(Call<RideResponseDTO> call, Response<RideResponseDTO> response) {

--- a/mobile-application/app/src/main/java/com/example/mobile_application/ui/track_ride/CancelRideDialogFragment.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/ui/track_ride/CancelRideDialogFragment.java
@@ -1,0 +1,195 @@
+
+package com.example.mobile_application.ui.track_ride;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import com.example.mobile_application.R;
+import com.example.mobile_application.dto.CancelRideRequestDTO;
+import com.example.mobile_application.dto.CancelRideResponseDTO;
+import com.example.mobile_application.repository.RideCancelRepository;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class CancelRideDialogFragment extends DialogFragment {
+
+    private static final String ARG_RIDE_ID = "ride_id";
+    private static final String ARG_USER_ID = "user_id";
+    private static final String ARG_FROM = "from";
+    private static final String ARG_TO = "to";
+    private static final String ARG_DRIVER = "driver";
+
+    private Long rideId;
+    private Long userId;
+
+    private EditText etReason;
+    private Button btnCancel, btnGoBack;
+    private TextView tvFrom, tvTo, tvDriver, tvError;
+    private LinearLayout layoutForm, layoutSuccess;
+    private RideCancelRepository repository;
+
+    public interface OnRideCancelledListener {
+        void onRideCancelled();
+    }
+
+    public static CancelRideDialogFragment newInstance(Long rideId, Long userId,
+                                                       String from, String to,
+                                                       String driver) {
+        CancelRideDialogFragment fragment = new CancelRideDialogFragment();
+        Bundle args = new Bundle();
+        args.putLong(ARG_RIDE_ID, rideId);
+        args.putLong(ARG_USER_ID, userId);
+        args.putString(ARG_FROM, from);
+        args.putString(ARG_TO, to);
+        args.putString(ARG_DRIVER, driver);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            rideId = getArguments().getLong(ARG_RIDE_ID);
+            userId = getArguments().getLong(ARG_USER_ID);
+        }
+        repository = new RideCancelRepository();
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        Dialog dialog = super.onCreateDialog(savedInstanceState);
+        if (dialog.getWindow() != null) {
+            dialog.getWindow().requestFeature(Window.FEATURE_NO_TITLE);
+        }
+        return dialog;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.dialog_cancel_ride, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        tvFrom = view.findViewById(R.id.tvCancelFrom);
+        tvTo = view.findViewById(R.id.tvCancelTo);
+        tvDriver = view.findViewById(R.id.tvCancelDriver);
+        tvError = view.findViewById(R.id.tvCancelError);
+        etReason = view.findViewById(R.id.etCancelReason);
+        btnCancel = view.findViewById(R.id.btnConfirmCancel);
+        btnGoBack = view.findViewById(R.id.btnCancelGoBack);
+        layoutForm = view.findViewById(R.id.layoutCancelForm);
+        layoutSuccess = view.findViewById(R.id.layoutCancelSuccess);
+
+        Bundle args = getArguments();
+        if (args != null) {
+            tvFrom.setText(args.getString(ARG_FROM, ""));
+            tvTo.setText(args.getString(ARG_TO, ""));
+            tvDriver.setText(args.getString(ARG_DRIVER, ""));
+        }
+
+        btnGoBack.setOnClickListener(v -> dismiss());
+        btnCancel.setOnClickListener(v -> performCancel());
+    }
+
+    private void performCancel() {
+        String reason = etReason.getText().toString().trim();
+        if (reason.isEmpty()) {
+            tvError.setText("Please provide a reason for cancellation");
+            tvError.setVisibility(View.VISIBLE);
+            return;
+        }
+
+        tvError.setVisibility(View.GONE);
+        btnCancel.setEnabled(false);
+        btnCancel.setText("Cancelling...");
+        btnGoBack.setEnabled(false);
+
+        CancelRideRequestDTO request = new CancelRideRequestDTO(userId, reason);
+
+        repository.cancelRide(rideId, request, new Callback<CancelRideResponseDTO>() {
+            @Override
+            public void onResponse(@NonNull Call<CancelRideResponseDTO> call,
+                                   @NonNull Response<CancelRideResponseDTO> response) {
+                if (!isAdded()) return;
+
+                if (response.isSuccessful() && response.body() != null) {
+                    layoutForm.setVisibility(View.GONE);
+                    layoutSuccess.setVisibility(View.VISIBLE);
+
+                    View root = getView();
+                    if (root != null) {
+                        root.postDelayed(() -> {
+                            if (isAdded()) {
+                                if (getParentFragment() instanceof OnRideCancelledListener) {
+                                    ((OnRideCancelledListener) getParentFragment())
+                                            .onRideCancelled();
+                                }
+                                dismiss();
+                            }
+                        }, 2000);
+                    }
+                } else {
+                    handleError(response);
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<CancelRideResponseDTO> call,
+                                  @NonNull Throwable t) {
+                if (!isAdded()) return;
+                showError("Network error. Please try again.");
+            }
+        });
+    }
+
+    private void handleError(Response<CancelRideResponseDTO> response) {
+        try {
+            String errorBody = response.errorBody() != null
+                    ? response.errorBody().string() : "Failed to cancel ride.";
+            showError(errorBody);
+        } catch (Exception e) {
+            showError("Failed to cancel ride.");
+        }
+    }
+
+    private void showError(String message) {
+        tvError.setText(message);
+        tvError.setVisibility(View.VISIBLE);
+        btnCancel.setEnabled(true);
+        btnCancel.setText("Cancel Ride");
+        btnGoBack.setEnabled(true);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        if (getDialog() != null && getDialog().getWindow() != null) {
+            getDialog().getWindow().setLayout(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+    }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/ui/track_ride/PanicDialogFragment.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/ui/track_ride/PanicDialogFragment.java
@@ -1,0 +1,239 @@
+
+package com.example.mobile_application.ui.track_ride;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+
+import com.example.mobile_application.R;
+import com.example.mobile_application.dto.PanicAlertRequestDTO;
+import com.example.mobile_application.dto.PanicAlertResponseDTO;
+import com.example.mobile_application.repository.PanicRepository;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class PanicDialogFragment extends DialogFragment {
+
+    private static final String ARG_RIDE_ID = "ride_id";
+    private static final String ARG_USER_ID = "user_id";
+    private static final String ARG_DRIVER = "driver";
+    private static final String ARG_LOCATION = "location";
+
+    private Long rideId;
+    private Long userId;
+    private boolean panicActivated = false;
+
+    private LinearLayout layoutPrePanic, layoutPostPanic;
+    private TextView tvPanicDriver, tvPanicLocation, tvPanicError;
+    private TextView tvStatusAlert, tvStatusLocation, tvStatusHelp;
+    private Button btnActivate, btnCancelAlert, btnClosePanic;
+    private PanicRepository repository;
+
+    public static PanicDialogFragment newInstance(Long rideId, Long userId,
+                                                  String driver, String location) {
+        PanicDialogFragment fragment = new PanicDialogFragment();
+        Bundle args = new Bundle();
+        args.putLong(ARG_RIDE_ID, rideId);
+        args.putLong(ARG_USER_ID, userId);
+        args.putString(ARG_DRIVER, driver);
+        args.putString(ARG_LOCATION, location);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            rideId = getArguments().getLong(ARG_RIDE_ID);
+            userId = getArguments().getLong(ARG_USER_ID);
+        }
+        repository = new PanicRepository();
+        setCancelable(false);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        Dialog dialog = super.onCreateDialog(savedInstanceState);
+        if (dialog.getWindow() != null) {
+            dialog.getWindow().requestFeature(Window.FEATURE_NO_TITLE);
+        }
+        return dialog;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.dialog_panic, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        layoutPrePanic = view.findViewById(R.id.layoutPrePanic);
+        layoutPostPanic = view.findViewById(R.id.layoutPostPanic);
+        tvPanicDriver = view.findViewById(R.id.tvPanicDriver);
+        tvPanicLocation = view.findViewById(R.id.tvPanicLocation);
+        tvPanicError = view.findViewById(R.id.tvPanicError);
+        tvStatusAlert = view.findViewById(R.id.tvStatusAlert);
+        tvStatusLocation = view.findViewById(R.id.tvStatusLocation);
+        tvStatusHelp = view.findViewById(R.id.tvStatusHelp);
+        btnActivate = view.findViewById(R.id.btnActivatePanic);
+        btnCancelAlert = view.findViewById(R.id.btnCancelPanicAlert);
+        btnClosePanic = view.findViewById(R.id.btnClosePanic);
+
+        Bundle args = getArguments();
+        if (args != null) {
+            tvPanicDriver.setText(args.getString(ARG_DRIVER, ""));
+            tvPanicLocation.setText(args.getString(ARG_LOCATION, ""));
+        }
+
+        btnClosePanic.setOnClickListener(v -> {
+            if (panicActivated) {
+                showToast("Cannot close while alert is active.");
+            } else {
+                dismiss();
+            }
+        });
+
+        btnActivate.setOnClickListener(v -> confirmAndActivate());
+        btnCancelAlert.setOnClickListener(v -> confirmCancelAlert());
+    }
+
+    private void confirmAndActivate() {
+        new AlertDialog.Builder(requireContext())
+                .setTitle("Confirm PANIC")
+                .setMessage("Are you sure? This will immediately notify all administrators.")
+                .setPositiveButton("Yes, activate", (d, w) -> activatePanic())
+                .setNegativeButton("No", null)
+                .show();
+    }
+
+    private void activatePanic() {
+        tvPanicError.setVisibility(View.GONE);
+        btnActivate.setEnabled(false);
+        btnActivate.setText("SENDING ALERT...");
+
+        String location = getArguments() != null
+                ? getArguments().getString(ARG_LOCATION, "45.2550, 19.8450")
+                : "45.2550, 19.8450";
+
+        PanicAlertRequestDTO request = new PanicAlertRequestDTO(
+                rideId, userId, location);
+
+        repository.triggerPanic(request, new Callback<PanicAlertResponseDTO>() {
+            @Override
+            public void onResponse(@NonNull Call<PanicAlertResponseDTO> call,
+                                   @NonNull Response<PanicAlertResponseDTO> response) {
+                if (!isAdded()) return;
+
+                if (response.isSuccessful()) {
+                    panicActivated = true;
+                    layoutPrePanic.setVisibility(View.GONE);
+                    layoutPostPanic.setVisibility(View.VISIBLE);
+                    animateStatusMessages();
+                } else {
+                    showPanicError(response);
+                }
+
+                android.util.Log.d("PANIC_DEBUG", "Response code: " + response.code());
+                if (!response.isSuccessful() && response.errorBody() != null) {
+                    try {
+                        android.util.Log.d("PANIC_DEBUG", "Error: " + response.errorBody().string());
+                    } catch (Exception e) { }
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<PanicAlertResponseDTO> call,
+                                  @NonNull Throwable t) {
+                if (!isAdded()) return;
+                tvPanicError.setText("Network error. Call emergency services directly.");
+                tvPanicError.setVisibility(View.VISIBLE);
+                btnActivate.setEnabled(true);
+                btnActivate.setText("ACTIVATE PANIC ALERT");
+            }
+        });
+    }
+
+    private void animateStatusMessages() {
+        View view = getView();
+        if (view == null) return;
+
+        tvStatusAlert.setVisibility(View.GONE);
+        tvStatusLocation.setVisibility(View.GONE);
+        tvStatusHelp.setVisibility(View.GONE);
+
+        view.postDelayed(() -> {
+            if (isAdded()) tvStatusAlert.setVisibility(View.VISIBLE);
+        }, 500);
+
+        view.postDelayed(() -> {
+            if (isAdded()) tvStatusLocation.setVisibility(View.VISIBLE);
+        }, 1500);
+
+        view.postDelayed(() -> {
+            if (isAdded()) tvStatusHelp.setVisibility(View.VISIBLE);
+        }, 2500);
+    }
+
+    private void confirmCancelAlert() {
+        new AlertDialog.Builder(requireContext())
+                .setTitle("Cancel Alert")
+                .setMessage("Are you sure? Administrators have already been notified.")
+                .setPositiveButton("Yes, false alarm", (d, w) -> {
+                    panicActivated = false;
+                    dismiss();
+                })
+                .setNegativeButton("No", null)
+                .show();
+    }
+
+    private void showPanicError(Response<PanicAlertResponseDTO> response) {
+        try {
+            String error = response.errorBody() != null
+                    ? response.errorBody().string()
+                    : "Failed to send alert.";
+            tvPanicError.setText(error);
+        } catch (Exception e) {
+            tvPanicError.setText("Failed to send alert.");
+        }
+        tvPanicError.setVisibility(View.VISIBLE);
+        btnActivate.setEnabled(true);
+        btnActivate.setText("ACTIVATE PANIC ALERT");
+    }
+
+    private void showToast(String message) {
+        if (isAdded()) {
+            android.widget.Toast.makeText(requireContext(), message,
+                    android.widget.Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        if (getDialog() != null && getDialog().getWindow() != null) {
+            getDialog().getWindow().setLayout(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+    }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/ui/track_ride/StopRideDialogFragment.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/ui/track_ride/StopRideDialogFragment.java
@@ -1,0 +1,229 @@
+
+package com.example.mobile_application.ui.track_ride;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import com.example.mobile_application.R;
+import com.example.mobile_application.dto.StopRideRequestDTO;
+import com.example.mobile_application.dto.StopRideResponseDTO;
+import com.example.mobile_application.repository.RideStopRepository;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class StopRideDialogFragment extends DialogFragment {
+
+    private static final String ARG_RIDE_ID = "ride_id";
+    private static final String ARG_PASSENGER = "passenger";
+    private static final String ARG_DESTINATION = "destination";
+    private static final String ARG_PRICE = "price";
+    private static final String ARG_DISTANCE = "distance";
+
+    private Long rideId;
+
+    private TextView tvPassenger, tvDestination, tvOriginalPrice,
+            tvNewPrice, tvError;
+    private EditText etLocation;
+    private Button btnStop, btnContinue;
+    private LinearLayout layoutForm, layoutSuccess;
+    private TextView tvSuccessLocation, tvSuccessPrice;
+    private RideStopRepository repository;
+
+    public interface OnRideStoppedListener {
+        void onRideStopped(String newDestination, double newPrice);
+    }
+
+    public static StopRideDialogFragment newInstance(Long rideId, String passenger,
+                                                     String destination, double price,
+                                                     double distance) {
+        StopRideDialogFragment fragment = new StopRideDialogFragment();
+        Bundle args = new Bundle();
+        args.putLong(ARG_RIDE_ID, rideId);
+        args.putString(ARG_PASSENGER, passenger);
+        args.putString(ARG_DESTINATION, destination);
+        args.putDouble(ARG_PRICE, price);
+        args.putDouble(ARG_DISTANCE, distance);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            rideId = getArguments().getLong(ARG_RIDE_ID);
+        }
+        repository = new RideStopRepository();
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        Dialog dialog = super.onCreateDialog(savedInstanceState);
+        if (dialog.getWindow() != null) {
+            dialog.getWindow().requestFeature(Window.FEATURE_NO_TITLE);
+        }
+        return dialog;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.dialog_stop_ride, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        tvPassenger = view.findViewById(R.id.tvStopPassenger);
+        tvDestination = view.findViewById(R.id.tvStopDestination);
+        tvOriginalPrice = view.findViewById(R.id.tvStopOriginalPrice);
+        tvNewPrice = view.findViewById(R.id.tvStopNewPrice);
+        tvError = view.findViewById(R.id.tvStopError);
+        etLocation = view.findViewById(R.id.etStopLocation);
+        btnStop = view.findViewById(R.id.btnConfirmStop);
+        btnContinue = view.findViewById(R.id.btnContinueRide);
+        layoutForm = view.findViewById(R.id.layoutStopForm);
+        layoutSuccess = view.findViewById(R.id.layoutStopSuccess);
+        tvSuccessLocation = view.findViewById(R.id.tvStopSuccessLocation);
+        tvSuccessPrice = view.findViewById(R.id.tvStopSuccessPrice);
+
+        Bundle args = getArguments();
+        if (args != null) {
+            tvPassenger.setText(args.getString(ARG_PASSENGER, ""));
+            tvDestination.setText(args.getString(ARG_DESTINATION, ""));
+            tvOriginalPrice.setText(String.format(Locale.getDefault(),
+                    "%.0f RSD", args.getDouble(ARG_PRICE)));
+
+            double distance = args.getDouble(ARG_DISTANCE, 0);
+            double estimated = 300 + (distance * 120);
+            tvNewPrice.setText(String.format(Locale.getDefault(),
+                    "~%.0f RSD", estimated));
+        }
+
+        etLocation.setText(getCurrentCoordinates());
+
+        btnContinue.setOnClickListener(v -> dismiss());
+        btnStop.setOnClickListener(v -> performStop());
+    }
+
+    private String getCurrentCoordinates() {
+        return "45.2550, 19.8450";
+    }
+
+    private String getCurrentIsoTimestamp() {
+        SimpleDateFormat sdf = new SimpleDateFormat(
+                "yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault());
+        sdf.setTimeZone(TimeZone.getDefault());
+        return sdf.format(new Date());
+    }
+
+    private void performStop() {
+        String location = etLocation.getText().toString().trim();
+        if (location.isEmpty()) {
+            tvError.setText("Cannot determine current location.");
+            tvError.setVisibility(View.VISIBLE);
+            return;
+        }
+
+        tvError.setVisibility(View.GONE);
+        btnStop.setEnabled(false);
+        btnStop.setText("Stopping...");
+        btnContinue.setEnabled(false);
+
+        StopRideRequestDTO request = new StopRideRequestDTO(
+                location, getCurrentIsoTimestamp());
+
+        repository.stopRide(rideId, request, new Callback<StopRideResponseDTO>() {
+            @Override
+            public void onResponse(@NonNull Call<StopRideResponseDTO> call,
+                                   @NonNull Response<StopRideResponseDTO> response) {
+                if (!isAdded()) return;
+
+                if (response.isSuccessful() && response.body() != null) {
+                    StopRideResponseDTO body = response.body();
+
+                    tvSuccessLocation.setText(body.getStoppedLocation());
+                    tvSuccessPrice.setText(String.format(Locale.getDefault(),
+                            "%.0f RSD", body.getRecalculatedPrice()));
+
+                    layoutForm.setVisibility(View.GONE);
+                    layoutSuccess.setVisibility(View.VISIBLE);
+
+                    View root = getView();
+                    if (root != null) {
+                        root.postDelayed(() -> {
+                            if (isAdded()) {
+                                if (getParentFragment() instanceof OnRideStoppedListener) {
+                                    ((OnRideStoppedListener) getParentFragment())
+                                            .onRideStopped(body.getStoppedLocation(),
+                                                    body.getRecalculatedPrice());
+                                }
+                                dismiss();
+                            }
+                        }, 3000);
+                    }
+                } else {
+                    handleError(response);
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<StopRideResponseDTO> call,
+                                  @NonNull Throwable t) {
+                if (!isAdded()) return;
+                showError("Network error. Please try again.");
+            }
+        });
+    }
+
+    private void handleError(Response<StopRideResponseDTO> response) {
+        try {
+            String errorBody = response.errorBody() != null
+                    ? response.errorBody().string() : "Failed to stop ride.";
+            showError(errorBody);
+        } catch (Exception e) {
+            showError("Failed to stop ride.");
+        }
+    }
+
+    private void showError(String message) {
+        tvError.setText(message);
+        tvError.setVisibility(View.VISIBLE);
+        btnStop.setEnabled(true);
+        btnStop.setText("Stop Ride Here");
+        btnContinue.setEnabled(true);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        if (getDialog() != null && getDialog().getWindow() != null) {
+            getDialog().getWindow().setLayout(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+    }
+}

--- a/mobile-application/app/src/main/java/com/example/mobile_application/ui/track_ride/TrackRideFragment.java
+++ b/mobile-application/app/src/main/java/com/example/mobile_application/ui/track_ride/TrackRideFragment.java
@@ -44,10 +44,13 @@ import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-public class TrackRideFragment extends Fragment {
+public class TrackRideFragment extends Fragment
+        implements StopRideDialogFragment.OnRideStoppedListener,
+        CancelRideDialogFragment.OnRideCancelledListener {
+
     private MapView mapView;
     private Marker vehicleMarker;
-    private Button btnPanic, btnReport, btnFinish, btnStop;
+    private Button btnPanic, btnReport, btnFinish, btnStop, btnCancel;
     private TextView tvRouteName, tvStartedAt, tvTimeLeft,
             tvDriver, tvPrice, tvPassengers, tvReports,
             tvPassengersHeading, tvReportsHeading;
@@ -67,6 +70,49 @@ public class TrackRideFragment extends Fragment {
     private DrawMarkerHelper drawMarkerHelper;
     private TrackRideDTO dto;
 
+    // ── Fallback helpers for when tracking endpoint fails ────────
+    private String getDriverName() {
+        if (dto != null && dto.getInfo() != null && dto.getInfo().getDriver() != null)
+            return dto.getInfo().getDriver();
+        return "Driver";
+    }
+
+    private String getFromLocation() {
+        if (dto != null && dto.getInfo() != null && dto.getInfo().getFrom() != null)
+            return dto.getInfo().getFrom();
+        return "Unknown";
+    }
+
+    private String getToLocation() {
+        if (dto != null && dto.getInfo() != null && dto.getInfo().getTo() != null)
+            return dto.getInfo().getTo();
+        return "Unknown";
+    }
+
+    private double getRidePrice() {
+        if (dto != null && dto.getInfo() != null)
+            return dto.getInfo().getPrice();
+        return 0.0;
+    }
+
+    private String getFirstPassenger() {
+        if (dto != null && dto.getInfo() != null
+                && dto.getInfo().getPassengers() != null
+                && !dto.getInfo().getPassengers().isEmpty())
+            return dto.getInfo().getPassengers().get(0);
+        return "Passenger";
+    }
+
+    private String getCurrentVehicleLocation() {
+        if (vehicleMarker != null) {
+            return vehicleMarker.getPosition().getLatitude()
+                    + ", " + vehicleMarker.getPosition().getLongitude();
+        }
+        return "45.2550, 19.8450";
+    }
+
+    // ── Fragment lifecycle ───────────────────────────────────────
+
     public static TrackRideFragment newInstance(Long rideId) {
         TrackRideFragment fragment = new TrackRideFragment();
         Bundle args = new Bundle();
@@ -78,7 +124,6 @@ public class TrackRideFragment extends Fragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         if (getArguments() != null) {
             rideId = getArguments().getLong(ARG_RIDE_ID);
         }
@@ -86,7 +131,7 @@ public class TrackRideFragment extends Fragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
-            Bundle savedInstanceState) {
+                             Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_track_ride, container, false);
 
         mapView = view.findViewById(R.id.map);
@@ -94,6 +139,7 @@ public class TrackRideFragment extends Fragment {
         btnReport = view.findViewById(R.id.btnReport);
         btnFinish = view.findViewById(R.id.btnFinish);
         btnStop = view.findViewById(R.id.btnStop);
+        btnCancel = view.findViewById(R.id.btnCancel);
         tvRouteName = view.findViewById(R.id.tvRouteName);
         tvStartedAt = view.findViewById(R.id.tvStartedAt);
         tvTimeLeft = view.findViewById(R.id.tvTimeLeft);
@@ -105,18 +151,19 @@ public class TrackRideFragment extends Fragment {
         tvReportsHeading = view.findViewById(R.id.tvReportsHeading);
         viewButtons = view.findViewById(R.id.viewButtons);
         viewPassengers = view.findViewById(R.id.viewPassengers);
+
         trackRideRepository = new TrackRideRepository();
         activeVehicleRepository = new ActiveVehicleRepository();
         rideRepository = new RideRepository();
 
         int newSize = 36;
-        Bitmap originalBitmap = ((BitmapDrawable) ContextCompat.getDrawable(requireContext(), R.drawable.taxi))
-                .getBitmap();
+        Bitmap originalBitmap = ((BitmapDrawable) ContextCompat.getDrawable(
+                requireContext(), R.drawable.taxi)).getBitmap();
         Bitmap smallBitmap = Bitmap.createScaledBitmap(originalBitmap, newSize, newSize, true);
         taxiIcon = new BitmapDrawable(getResources(), smallBitmap);
 
-        originalBitmap = ((BitmapDrawable) ContextCompat.getDrawable(requireContext(), R.drawable.location_icon))
-                .getBitmap();
+        originalBitmap = ((BitmapDrawable) ContextCompat.getDrawable(
+                requireContext(), R.drawable.location_icon)).getBitmap();
         smallBitmap = Bitmap.createScaledBitmap(originalBitmap, newSize, newSize, true);
         stopIcon = new BitmapDrawable(getResources(), smallBitmap);
 
@@ -124,11 +171,19 @@ public class TrackRideFragment extends Fragment {
         mapRouteHelper = new MapRouteHelper(mapView);
         drawMarkerHelper = new DrawMarkerHelper(mapView);
 
+        // All buttons work regardless of whether dto is loaded
         btnFinish.setOnClickListener(v -> finishRide());
         btnReport.setOnClickListener(v -> reportDriver());
+        btnPanic.setOnClickListener(v -> openPanicDialog());
+        btnStop.setOnClickListener(v -> openStopDialog());
+        if (btnCancel != null) {
+            btnCancel.setOnClickListener(v -> openCancelDialog());
+        }
 
         return view;
     }
+
+    // ── Map setup ────────────────────────────────────────────────
 
     private void mapSetup() {
         Configuration.getInstance().setUserAgentValue(requireContext().getPackageName());
@@ -149,17 +204,18 @@ public class TrackRideFragment extends Fragment {
     }
 
     private void showToast(String message) {
-        requireActivity().runOnUiThread(() -> Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show());
+        requireActivity().runOnUiThread(() ->
+                Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show());
     }
+
+    // ── Load ride data ───────────────────────────────────────────
 
     private void loadRide() {
         trackRideRepository.trackRide(rideId, new Callback<TrackRideDTO>() {
             @Override
-            public void onResponse(
-                    @NonNull Call<TrackRideDTO> call,
-                    @NonNull Response<TrackRideDTO> response) {
-                if (!isAdded())
-                    return;
+            public void onResponse(@NonNull Call<TrackRideDTO> call,
+                                   @NonNull Response<TrackRideDTO> response) {
+                if (!isAdded()) return;
 
                 if (response.isSuccessful() && response.body() != null) {
                     dto = response.body();
@@ -168,68 +224,63 @@ public class TrackRideFragment extends Fragment {
                         updateRideStaticUI(dto);
                         showRoute(dto.getStops());
                     }
-
                     updateTimeLeft(dto);
 
                     driverId = dto.getDriverId();
                     loadVehicle(driverId);
+                } else {
+                    // Tracking failed (e.g. 500) — log but don't block UI
+                    android.util.Log.w("TrackRide",
+                            "Tracking endpoint returned " + response.code()
+                                    + " — buttons still work");
                 }
             }
 
             @Override
-            public void onFailure(
-                    @NonNull Call<TrackRideDTO> call,
-                    @NonNull Throwable t) {
-                if (isAdded())
-                    showToast("Failed loading ride to track");
+            public void onFailure(@NonNull Call<TrackRideDTO> call,
+                                  @NonNull Throwable t) {
+                if (isAdded()) {
+                    android.util.Log.w("TrackRide",
+                            "Tracking network error: " + t.getMessage());
+                }
             }
         });
     }
 
     private void loadVehicle(Long driverId) {
-        if (driverId == null)
-            return;
+        if (driverId == null) return;
 
         activeVehicleRepository.getDriversVehicle(driverId,
                 new Callback<ActiveVehicleDTO>() {
                     @Override
-                    public void onResponse(
-                            @NonNull Call<ActiveVehicleDTO> call,
-                            @NonNull Response<ActiveVehicleDTO> response) {
-
-                        if (!isAdded())
-                            return;
-
+                    public void onResponse(@NonNull Call<ActiveVehicleDTO> call,
+                                           @NonNull Response<ActiveVehicleDTO> response) {
+                        if (!isAdded()) return;
                         if (response.isSuccessful() && response.body() != null) {
                             updateVehicleMarker(response.body());
                         }
                     }
 
                     @Override
-                    public void onFailure(
-                            @NonNull Call<ActiveVehicleDTO> call,
-                            @NonNull Throwable t) {
-                        if (isAdded())
-                            showToast("Failed showing driver's vehicle");
+                    public void onFailure(@NonNull Call<ActiveVehicleDTO> call,
+                                          @NonNull Throwable t) {
                     }
                 });
     }
 
     private void updateVehicleMarker(ActiveVehicleDTO vehicle) {
-        GeoPoint point = new GeoPoint(
-                vehicle.getLatitude(),
-                vehicle.getLongitude());
-
+        GeoPoint point = new GeoPoint(vehicle.getLatitude(), vehicle.getLongitude());
         if (vehicleMarker == null) {
             vehicleMarker = new Marker(mapView);
             vehicleMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
             vehicleMarker.setIcon(taxiIcon);
             mapView.getOverlays().add(vehicleMarker);
         }
-
         vehicleMarker.setPosition(point);
         mapView.invalidate();
     }
+
+    // ── UI updates ───────────────────────────────────────────────
 
     private void updateRideStaticUI(TrackRideDTO dto) {
         TokenManager tokenManager = ApiClient.getTokenManager();
@@ -243,6 +294,7 @@ public class TrackRideFragment extends Fragment {
         tvPassengers.setText(passengersText);
         String reportsText = TextUtils.join("\n", dto.getInfo().getReports());
         tvReports.setText(reportsText);
+
         if (userRole.equals(getString(R.string.role_passenger)))
             setVisibilityPassenger();
         if (userRole.equals(getString(R.string.role_driver)))
@@ -282,17 +334,18 @@ public class TrackRideFragment extends Fragment {
         btnFinish.setVisibility(View.GONE);
         btnReport.setVisibility(View.GONE);
         btnPanic.setVisibility(View.GONE);
+        if (btnCancel != null) btnCancel.setVisibility(View.GONE);
         viewButtons.setVisibility(View.GONE);
     }
 
-    // TODO: live time left update
     private void updateTimeLeft(TrackRideDTO dto) {
         tvTimeLeft.setText(String.format("%d min", dto.getInfo().getDuration()));
     }
 
+    // ── Auto refresh ─────────────────────────────────────────────
+
     private void startAutoRefresh() {
-        if (refreshRunnable != null)
-            return;
+        if (refreshRunnable != null) return;
         refreshRunnable = new Runnable() {
             @Override
             public void run() {
@@ -310,6 +363,103 @@ public class TrackRideFragment extends Fragment {
         }
     }
 
+    // ── Dialog openers (NO dto null check — use fallbacks) ──────
+
+    private void openPanicDialog() {
+        TokenManager tokenManager = ApiClient.getTokenManager();
+
+        PanicDialogFragment dialog = PanicDialogFragment.newInstance(
+                rideId,
+                tokenManager.getUserId(),
+                getDriverName(),
+                getCurrentVehicleLocation());
+
+        dialog.show(getChildFragmentManager(), "panic_dialog");
+    }
+
+    private void openStopDialog() {
+        StopRideDialogFragment dialog = StopRideDialogFragment.newInstance(
+                rideId,
+                getFirstPassenger(),
+                getToLocation(),
+                getRidePrice(),
+                5.5);
+
+        dialog.show(getChildFragmentManager(), "stop_dialog");
+    }
+
+    private void openCancelDialog() {
+        TokenManager tokenManager = ApiClient.getTokenManager();
+
+        CancelRideDialogFragment dialog = CancelRideDialogFragment.newInstance(
+                rideId,
+                tokenManager.getUserId(),
+                getFromLocation(),
+                getToLocation(),
+                getDriverName());
+
+        dialog.show(getChildFragmentManager(), "cancel_dialog");
+    }
+
+    // ── Callbacks from dialogs ───────────────────────────────────
+
+    @Override
+    public void onRideStopped(String newDestination, double newPrice) {
+        showToast("Ride stopped. New price: " + (int) newPrice + " RSD");
+        if (isAdded()) {
+            requireActivity().getSupportFragmentManager().popBackStack();
+        }
+    }
+
+    @Override
+    public void onRideCancelled() {
+        showToast("Ride cancelled successfully");
+        if (isAdded()) {
+            requireActivity().getSupportFragmentManager().popBackStack();
+        }
+    }
+
+    // ── Actions ──────────────────────────────────────────────────
+
+    public void finishRide() {
+        btnFinish.setEnabled(false);
+        rideRepository.finishRide(rideId, new Callback<Void>() {
+            @Override
+            public void onResponse(@NonNull Call<Void> call,
+                                   @NonNull Response<Void> response) {
+                btnFinish.setEnabled(true);
+                if (response.isSuccessful()) {
+                    if (isAdded()) showToast("Ride successfully finished!");
+                } else {
+                    if (isAdded()) showToast("Error while finishing the ride");
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<Void> call,
+                                  @NonNull Throwable t) {
+                btnFinish.setEnabled(true);
+                if (isAdded()) showToast("Failed finishing ride");
+            }
+        });
+        requireActivity().getSupportFragmentManager().popBackStack();
+    }
+
+    public void reportDriver() {
+        if (dto == null) {
+            showToast("Ride data not loaded yet. Please try again.");
+            return;
+        }
+        Fragment fragment = IrregularityReportFragment.newInstance(dto);
+        requireActivity().getSupportFragmentManager()
+                .beginTransaction()
+                .add(R.id.main_container, fragment)
+                .addToBackStack(null)
+                .commit();
+    }
+
+    // ── Lifecycle ────────────────────────────────────────────────
+
     @Override
     public void onResume() {
         super.onResume();
@@ -320,43 +470,5 @@ public class TrackRideFragment extends Fragment {
     public void onPause() {
         super.onPause();
         stopAutoRefresh();
-    }
-
-    public void finishRide() {
-        btnFinish.setEnabled(false);
-        rideRepository.finishRide(rideId, new Callback<Void>() {
-            @Override
-            public void onResponse(
-                    @NonNull Call<Void> call,
-                    @NonNull Response<Void> response) {
-                btnFinish.setEnabled(true);
-                if (response.isSuccessful()) {
-                    if (isAdded())
-                        showToast("Ride successfully finished!");
-                } else {
-                    if (isAdded())
-                        showToast("Error while finishing the ride");
-                }
-            }
-
-            @Override
-            public void onFailure(
-                    @NonNull Call<Void> call,
-                    @NonNull Throwable t) {
-                btnFinish.setEnabled(true);
-                if (isAdded())
-                    showToast("Failed finishing ride");
-            }
-        });
-        requireActivity().getSupportFragmentManager().popBackStack();
-    }
-
-    public void reportDriver() {
-        Fragment fragment = IrregularityReportFragment.newInstance(dto);
-        requireActivity().getSupportFragmentManager()
-                .beginTransaction()
-                .add(R.id.main_container, fragment)
-                .addToBackStack(null)
-                .commit();
     }
 }

--- a/mobile-application/app/src/main/res/layout/dialog_cancel_ride.xml
+++ b/mobile-application/app/src/main/res/layout/dialog_cancel_ride.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="?attr/colorSurface">
+
+    <!-- FORM -->
+    <LinearLayout
+        android:id="@+id/layoutCancelForm"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Cancel Ride"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:layout_marginBottom="16dp"/>
+
+        <!-- Ride details -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Current Ride Details"
+            android:textStyle="bold"
+            android:textSize="14sp"
+            android:layout_marginBottom="8dp"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="4dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="From: "
+                android:textStyle="bold"/>
+            <TextView
+                android:id="@+id/tvCancelFrom"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="4dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="To: "
+                android:textStyle="bold"/>
+            <TextView
+                android:id="@+id/tvCancelTo"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="12dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Driver: "
+                android:textStyle="bold"/>
+            <TextView
+                android:id="@+id/tvCancelDriver"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
+        </LinearLayout>
+
+        <!-- Reason input -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etCancelReason"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Reason for cancellation"
+                android:inputType="textMultiLine"
+                android:minLines="3"
+                android:gravity="top"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Error -->
+        <TextView
+            android:id="@+id/tvCancelError"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/holo_red_dark"
+            android:visibility="gone"
+            android:layout_marginBottom="8dp"/>
+
+        <!-- Warning -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="⚠️ Passengers can only cancel 10 minutes before scheduled start. Drivers can cancel anytime before ride starts."
+            android:textSize="12sp"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:layout_marginBottom="16dp"/>
+
+        <!-- Buttons -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+
+            <Button
+                android:id="@+id/btnCancelGoBack"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Go Back"
+                android:layout_marginEnd="8dp"
+                style="@style/Widget.MaterialComponents.Button.TextButton"/>
+
+            <Button
+                android:id="@+id/btnConfirmCancel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Cancel Ride"
+                android:backgroundTint="@android:color/holo_red_dark"
+                style="@style/Widget.MaterialComponents.Button"/>
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- SUCCESS -->
+    <LinearLayout
+        android:id="@+id/layoutCancelSuccess"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:padding="32dp"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="✓"
+            android:textSize="48sp"
+            android:textColor="@android:color/holo_green_dark"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Ride Canceled Successfully"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:layout_marginTop="8dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="All participants have been notified."
+            android:layout_marginTop="4dp"/>
+    </LinearLayout>
+
+</LinearLayout>

--- a/mobile-application/app/src/main/res/layout/dialog_panic.xml
+++ b/mobile-application/app/src/main/res/layout/dialog_panic.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="?attr/colorSurface">
+
+    <!-- PRE-PANIC -->
+    <LinearLayout
+        android:id="@+id/layoutPrePanic"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="12dp">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="🚨 Emergency Alert"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                android:textColor="@android:color/holo_red_dark"/>
+
+            <Button
+                android:id="@+id/btnClosePanic"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="✕"
+                android:minWidth="0dp"
+                style="@style/Widget.MaterialComponents.Button.TextButton"/>
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Press the button below if you're in danger or need immediate assistance"
+            android:layout_marginBottom="16dp"/>
+
+        <!-- Current ride info -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="4dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="👤 Driver: "
+                android:textStyle="bold"/>
+            <TextView
+                android:id="@+id/tvPanicDriver"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="12dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="📍 Location: "
+                android:textStyle="bold"/>
+            <TextView
+                android:id="@+id/tvPanicLocation"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="⚠️ This will immediately alert all administrators"
+            android:textColor="@android:color/holo_orange_dark"
+            android:layout_marginBottom="16dp"/>
+
+        <!-- Error -->
+        <TextView
+            android:id="@+id/tvPanicError"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/holo_red_dark"
+            android:visibility="gone"
+            android:layout_marginBottom="8dp"/>
+
+        <Button
+            android:id="@+id/btnActivatePanic"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:text="ACTIVATE PANIC ALERT"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:backgroundTint="@android:color/holo_red_dark"
+            style="@style/Widget.MaterialComponents.Button"/>
+    </LinearLayout>
+
+    <!-- POST-PANIC (activated) -->
+    <LinearLayout
+        android:id="@+id/layoutPostPanic"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="🚨"
+            android:textSize="56sp"
+            android:layout_marginBottom="12dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Emergency Alert Activated"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:textColor="@android:color/holo_red_dark"
+            android:layout_marginBottom="16dp"/>
+
+        <!-- Status messages (animated in) -->
+        <TextView
+            android:id="@+id/tvStatusAlert"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="✓ Alert sent to administrators"
+            android:textColor="@android:color/holo_green_dark"
+            android:textSize="14sp"
+            android:visibility="gone"
+            android:layout_marginBottom="8dp"/>
+
+        <TextView
+            android:id="@+id/tvStatusLocation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="✓ Your location has been shared"
+            android:textColor="@android:color/holo_green_dark"
+            android:textSize="14sp"
+            android:visibility="gone"
+            android:layout_marginBottom="8dp"/>
+
+        <TextView
+            android:id="@+id/tvStatusHelp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="✓ Help is being dispatched"
+            android:textColor="@android:color/holo_green_dark"
+            android:textSize="14sp"
+            android:visibility="gone"
+            android:layout_marginBottom="16dp"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Stay calm. Help is on the way."
+            android:textStyle="bold"
+            android:textSize="16sp"
+            android:gravity="center"
+            android:layout_marginBottom="4dp"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Administrators have been notified."
+            android:gravity="center"
+            android:layout_marginBottom="4dp"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Emergency contact: +381 21 123 4567"
+            android:textStyle="bold"
+            android:gravity="center"
+            android:layout_marginBottom="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelPanicAlert"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Cancel Alert (False Alarm)"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"/>
+    </LinearLayout>
+
+</LinearLayout>

--- a/mobile-application/app/src/main/res/layout/dialog_stop_ride.xml
+++ b/mobile-application/app/src/main/res/layout/dialog_stop_ride.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="?attr/colorSurface">
+
+    <!-- FORM -->
+    <LinearLayout
+        android:id="@+id/layoutStopForm"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Stop Ride"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:layout_marginBottom="16dp"/>
+
+        <!-- Ride info -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="4dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Passenger: "
+                android:textStyle="bold"/>
+            <TextView
+                android:id="@+id/tvStopPassenger"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="4dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Destination: "
+                android:textStyle="bold"/>
+            <TextView
+                android:id="@+id/tvStopDestination"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="12dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Original price: "
+                android:textStyle="bold"/>
+            <TextView
+                android:id="@+id/tvStopOriginalPrice"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="⚠️ Passenger has requested to stop the ride early"
+            android:textColor="@android:color/holo_orange_dark"
+            android:layout_marginBottom="12dp"/>
+
+        <!-- Location -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etStopLocation"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Current location (coordinates)"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Estimated new price -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="8dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Estimated new price: "
+                android:textStyle="bold"/>
+            <TextView
+                android:id="@+id/tvStopNewPrice"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textStyle="bold"
+                android:textColor="?attr/colorPrimary"/>
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="* Final price will be calculated by the server"
+            android:textSize="11sp"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:layout_marginBottom="12dp"/>
+
+        <!-- Error -->
+        <TextView
+            android:id="@+id/tvStopError"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/holo_red_dark"
+            android:visibility="gone"
+            android:layout_marginBottom="8dp"/>
+
+        <!-- Buttons -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+
+            <Button
+                android:id="@+id/btnContinueRide"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Continue"
+                android:layout_marginEnd="8dp"
+                style="@style/Widget.MaterialComponents.Button.TextButton"/>
+
+            <Button
+                android:id="@+id/btnConfirmStop"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Stop Ride Here"
+                android:backgroundTint="@android:color/holo_red_dark"
+                style="@style/Widget.MaterialComponents.Button"/>
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- SUCCESS -->
+    <LinearLayout
+        android:id="@+id/layoutStopSuccess"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:padding="32dp"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="✓"
+            android:textSize="48sp"
+            android:textColor="@android:color/holo_green_dark"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Ride Stopped Successfully"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:layout_marginTop="8dp"/>
+
+        <TextView
+            android:id="@+id/tvStopSuccessLocation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"/>
+
+        <TextView
+            android:id="@+id/tvStopSuccessPrice"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textSize="16sp"
+            android:layout_marginTop="4dp"/>
+    </LinearLayout>
+
+</LinearLayout>

--- a/mobile-application/app/src/main/res/layout/view_ride_actions.xml
+++ b/mobile-application/app/src/main/res/layout/view_ride_actions.xml
@@ -37,4 +37,13 @@
         android:layout_marginBottom="8dp"
         style="@style/Widget.StopButton"/>
 
+    <Button
+        android:id="@+id/btnCancel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Cancel ride"
+        android:layout_marginBottom="8dp"
+        android:backgroundTint="@android:color/holo_orange_dark"
+        style="@style/Widget.MaterialComponents.Button"/>
+
 </LinearLayout>


### PR DESCRIPTION
Implement Panic, Stop Ride, and Cancel Ride functionality
Summary
Implements the three ride action dialogs for the Track Ride screen: Panic Alert (2.6.3), Stop Ride (2.6.5), and Cancel Ride (2.5).
Changes
New Dialog Fragments:

PanicDialogFragment — Emergency alert dialog with confirmation step, animated status messages after activation, and cancel alert option
StopRideDialogFragment — Allows driver to stop ride early, captures current location/timestamp, displays recalculated price from server
CancelRideDialogFragment — Cancellation form with mandatory reason input, shows ride details and success state

New DTOs:

PanicAlertRequestDTO / PanicAlertResponseDTO
StopRideRequestDTO / StopRideResponseDTO
CancelRideRequestDTO / CancelRideResponseDTO

New Services & Repositories:

PanicService → PanicRepository (POST /api/panic)
RideStopService → RideStopRepository (POST /api/rides/{rideId}/stop)
RideCancelService → RideCancelRepository (POST /api/rides/{rideId}/cancel)

New Layouts:

dialog_panic.xml — Pre/post panic states with emergency info
dialog_stop_ride.xml — Stop form with estimated price and success view
dialog_cancel_ride.xml — Cancel form with reason input and success view
Updated view_ride_actions.xml — Added Cancel Ride button

Modified:

TrackRideFragment — Connected all three dialogs, added fallback helpers so buttons work even when the tracking endpoint fails (handles 500 from /api/rides/{rideId}/tracking gracefully), added null check for report driver action